### PR TITLE
Added `sqrt(_:)` sugar

### DIFF
--- a/Sources/MultiplicativeArithmetic/MultiplicativeArithmetic.swift
+++ b/Sources/MultiplicativeArithmetic/MultiplicativeArithmetic.swift
@@ -64,14 +64,13 @@ public protocol MultiplicativeArithmetic {
     ///
     /// - SeeAlso: [Square root – Wikipedia](https://en.wikipedia.org/wiki/Square_root#Computation)
     ///
-    /// - Parameters:
-    ///   - x: The number whose square root to find
-    ///
-    /// - Returns: √x
+    /// - Returns: √self
     func sqrt() -> Self
 }
 
 
+
+// MARK: - Simplificatino
 
 /// A version of `MultiplicativeArithmetic` which is simpler to implement since some of it is synthesized
 public protocol SimpleMultiplicativeArithmetic: MultiplicativeArithmetic {
@@ -91,3 +90,18 @@ public extension SimpleMultiplicativeArithmetic {
         lhs = lhs / rhs
     }
 }
+
+
+
+// MARK: - Sugar
+
+/// Takes the square root of the given number
+///
+/// - SeeAlso: [Square root – Wikipedia](https://en.wikipedia.org/wiki/Square_root#Computation)
+///
+/// - Parameters:
+///   - x: The number whose square root to find
+///
+/// - Returns: √x
+@inline(__always)
+public func sqrt<Value: MultiplicativeArithmetic>(_ x: Value) -> Value { x.sqrt() }

--- a/Tests/MultiplicativeArithmeticTests/MultiplicativeArithmeticTests.swift
+++ b/Tests/MultiplicativeArithmeticTests/MultiplicativeArithmeticTests.swift
@@ -1,14 +1,17 @@
 import XCTest
-@testable import MultiplicativeArithmetic
+import MultiplicativeArithmetic
 
 
 
 final class MultiplicativeArithmeticTests: XCTestCase {
-    func testNothing() {
-        // I don't think there's anything to test 🤔
+    
+    func testSugar() {
+        XCTAssertEqual(sqrt(7.5), 7.5.sqrt())
+        XCTAssertEqual(Foundation.sqrt(7.5), sqrt<Double>(7.5))
     }
-
+    
+    
     static var allTests = [
-        ("testNothing", testNothing),
+        ("testSugar", testSugar),
     ]
 }


### PR DESCRIPTION
Yeah turns out `7.42.sqrt()` isn't as sweet as `sqrt(7.42)`